### PR TITLE
feat: ScreenCover 全屏覆盖组件

### DIFF
--- a/packages/pocket/package.json
+++ b/packages/pocket/package.json
@@ -61,6 +61,7 @@
     "rc-animate": "^3.1.1",
     "rc-slider": "^10.5.0",
     "rc-tooltip": "^6.1.3",
+    "rc-util": "^5.39.1",
     "react-transition-group": "^4.4.5",
     "react-window": "^1.8.10",
     "tslib": "^2.6.2"

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -64,6 +64,8 @@ import LoadMore from './load-more';
 import type { SimpleFormProps, SimpleFormItemProps } from './simple-form';
 import SimpleForm from './simple-form';
 import ViewportSensor3d from './viewport-sensor-3d';
+import ScreenCover from './screen-cover';
+import type { ScreenCoverProps } from './screen-cover';
 
 export type {
   EqRatioBoxProps,
@@ -106,6 +108,7 @@ export type {
   LoadMoreProps,
   SimpleFormProps,
   SimpleFormItemProps,
+  ScreenCoverProps,
 };
 
 export {
@@ -144,4 +147,5 @@ export {
   LoadMore,
   SimpleForm,
   ViewportSensor3d,
+  ScreenCover,
 };

--- a/packages/pocket/src/screen-cover/ScreenCover.style.ts
+++ b/packages/pocket/src/screen-cover/ScreenCover.style.ts
@@ -1,0 +1,32 @@
+import { createUseStyles } from '@orca-fe/simple-jss';
+import jssAutoPrefix from '@orca-fe/jss-plugin-auto-prefix';
+
+const prefix = 'screen-cover';
+
+export default createUseStyles(
+  {
+    root: {
+      position: 'relative',
+      visibility: 'hidden',
+    },
+    show: {
+      position: 'fixed',
+      left: 0,
+      top: 0,
+      width: '100vw',
+      height: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      visibility: 'visible',
+    },
+    mask: {
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    content: {},
+  },
+  {
+    classNamePrefix: prefix,
+    plugins: [jssAutoPrefix({ prefix })],
+  },
+);

--- a/packages/pocket/src/screen-cover/ScreenCover.style.ts
+++ b/packages/pocket/src/screen-cover/ScreenCover.style.ts
@@ -17,15 +17,17 @@ export default createUseStyles(
       top: 0,
       width: '100vw',
       height: '100vh',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
       visibility: 'visible',
     },
     mask: {
       backgroundColor: 'rgba(0, 0, 0, 0.5)',
     },
-    content: {},
+    content: {
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate3d(-50%, -50%, 0)',
+    },
   },
   {
     classNamePrefix: prefix,

--- a/packages/pocket/src/screen-cover/ScreenCover.style.ts
+++ b/packages/pocket/src/screen-cover/ScreenCover.style.ts
@@ -8,6 +8,8 @@ export default createUseStyles(
     root: {
       position: 'relative',
       visibility: 'hidden',
+      height: 0,
+      overflow: 'hidden',
     },
     show: {
       position: 'fixed',

--- a/packages/pocket/src/screen-cover/ScreenCover.tsx
+++ b/packages/pocket/src/screen-cover/ScreenCover.tsx
@@ -4,7 +4,16 @@ import cn from 'classnames';
 import { createPortal } from 'react-dom';
 import { useMemoizedFn } from 'ahooks';
 import setStyle from 'rc-util/es/setStyle';
+import { isNumber } from 'lodash-es';
 import useStyles from './ScreenCover.style';
+
+export type ScreenCoverContentPosition = {
+  top?: number | string;
+
+  left?: number | string;
+};
+
+const contentPos = (pos?: number | string) => (isNumber(pos) ? `${pos}px` : pos);
 
 export interface ScreenCoverProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
 
@@ -17,18 +26,23 @@ export interface ScreenCoverProps extends Omit<React.HTMLAttributes<HTMLDivEleme
   /** 是否锁定 body 滚动，true-全部锁定，false-不锁定 */
   bodyScrollLock?: boolean | 'x' | 'y';
 
+  /** 内容位置 */
+  position?: ScreenCoverContentPosition;
+
   /** 设置 z-index */
   zIndex?: number;
 }
 
 const ScreenCover = (props: ScreenCoverProps) => {
-  const { className = '', visible, mask = true, bodyScrollLock = false, zIndex = 1000, children, style = {}, ...otherProps } = props;
+  const { className = '', visible, mask = true, bodyScrollLock = true, position = {}, zIndex = 1000, children, style = {}, ...otherProps } = props;
   const styles = useStyles();
   const [_this] = useState<{ oldBodyStyle?: CSSProperties }>({});
 
   const node = (
     <div className={cn(styles.root, className, { [styles.show]: visible, [styles.mask]: mask })} style={{ zIndex, ...style }} {...otherProps}>
-      <div className={styles.content}>{children}</div>
+      <div className={styles.content} style={{ top: contentPos(position.top), left: contentPos(position.left) }}>
+        {children}
+      </div>
     </div>
   );
 

--- a/packages/pocket/src/screen-cover/ScreenCover.tsx
+++ b/packages/pocket/src/screen-cover/ScreenCover.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import cn from 'classnames';
+import { createPortal } from 'react-dom';
+import { useMount } from 'ahooks';
+import useStyles from './ScreenCover.style';
+
+export interface ScreenCoverProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+
+  /** 是否可见 */
+  open?: boolean;
+
+  /** 是否展示遮罩 */
+  mask?: boolean;
+
+  /** 是否锁定 body 滚动 */
+  bodyScrollLock?: boolean;
+
+  /** 设置 z-index */
+  zIndex?: number;
+}
+
+const ScreenCover = (props: ScreenCoverProps) => {
+  const { className = '', open, mask = true, bodyScrollLock = false, zIndex = 1000, children, style = {}, ...otherProps } = props;
+  const styles = useStyles();
+  const [_this] = useState<{ cachedOverflowY?: string }>({});
+
+  const node = (
+    <div className={cn(styles.root, className, { [styles.show]: open, [styles.mask]: mask })} style={{ zIndex, ...style }} {...otherProps}>
+      <div className={styles.content}>{children}</div>
+    </div>
+  );
+
+  useEffect(() => {
+    if (!bodyScrollLock) return;
+    if (open) {
+      document.body.style.overflowY = 'hidden';
+    } else {
+      document.body.style.overflowY = _this.cachedOverflowY ?? '';
+    }
+  }, [open, bodyScrollLock]);
+
+  useMount(() => {
+    _this.cachedOverflowY = document.body.style.overflowY;
+  });
+
+  return bodyScrollLock ? createPortal(node, document.body, 'ScreenCover') : node;
+};
+
+export default ScreenCover;

--- a/packages/pocket/src/screen-cover/ScreenCover.tsx
+++ b/packages/pocket/src/screen-cover/ScreenCover.tsx
@@ -34,7 +34,17 @@ export interface ScreenCoverProps extends Omit<React.HTMLAttributes<HTMLDivEleme
 }
 
 const ScreenCover = (props: ScreenCoverProps) => {
-  const { className = '', visible, mask = true, bodyScrollLock = true, position = {}, zIndex = 1000, children, style = {}, ...otherProps } = props;
+  const {
+    className = '',
+    visible = false,
+    mask = true,
+    bodyScrollLock = true,
+    position = {},
+    zIndex = 1000,
+    children,
+    style = {},
+    ...otherProps
+  } = props;
   const styles = useStyles();
   const [_this] = useState<{ oldBodyStyle?: CSSProperties }>({});
 

--- a/packages/pocket/src/screen-cover/ScreenCover.tsx
+++ b/packages/pocket/src/screen-cover/ScreenCover.tsx
@@ -1,49 +1,65 @@
+import type { CSSProperties } from 'react';
 import React, { useEffect, useState } from 'react';
 import cn from 'classnames';
 import { createPortal } from 'react-dom';
-import { useMount } from 'ahooks';
+import { useMemoizedFn } from 'ahooks';
+import setStyle from 'rc-util/es/setStyle';
 import useStyles from './ScreenCover.style';
 
 export interface ScreenCoverProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
 
   /** 是否可见 */
-  open?: boolean;
+  visible?: boolean;
 
   /** 是否展示遮罩 */
   mask?: boolean;
 
-  /** 是否锁定 body 滚动 */
-  bodyScrollLock?: boolean;
+  /** 是否锁定 body 滚动，true-全部锁定，false-不锁定 */
+  bodyScrollLock?: boolean | 'x' | 'y';
 
   /** 设置 z-index */
   zIndex?: number;
 }
 
 const ScreenCover = (props: ScreenCoverProps) => {
-  const { className = '', open, mask = true, bodyScrollLock = false, zIndex = 1000, children, style = {}, ...otherProps } = props;
+  const { className = '', visible, mask = true, bodyScrollLock = false, zIndex = 1000, children, style = {}, ...otherProps } = props;
   const styles = useStyles();
-  const [_this] = useState<{ cachedOverflowY?: string }>({});
+  const [_this] = useState<{ oldBodyStyle?: CSSProperties }>({});
 
   const node = (
-    <div className={cn(styles.root, className, { [styles.show]: open, [styles.mask]: mask })} style={{ zIndex, ...style }} {...otherProps}>
+    <div className={cn(styles.root, className, { [styles.show]: visible, [styles.mask]: mask })} style={{ zIndex, ...style }} {...otherProps}>
       <div className={styles.content}>{children}</div>
     </div>
   );
 
-  useEffect(() => {
-    if (!bodyScrollLock) return;
-    if (open) {
-      document.body.style.overflowY = 'hidden';
-    } else {
-      document.body.style.overflowY = _this.cachedOverflowY ?? '';
-    }
-  }, [open, bodyScrollLock]);
-
-  useMount(() => {
-    _this.cachedOverflowY = document.body.style.overflowY;
+  const lockBody = useMemoizedFn(() => {
+    const oldBodyStyle = setStyle(
+      {
+        overflow: bodyScrollLock === true ? 'hidden' : undefined,
+        overflowX: bodyScrollLock === 'x' ? 'hidden' : undefined,
+        overflowY: bodyScrollLock === 'y' ? 'hidden' : undefined,
+      },
+      { element: document.body },
+    );
+    _this.oldBodyStyle = oldBodyStyle;
   });
 
-  return bodyScrollLock ? createPortal(node, document.body, 'ScreenCover') : node;
+  const unlockBody = useMemoizedFn(() => {
+    setStyle(_this.oldBodyStyle ?? {}, { element: document.body });
+    _this.oldBodyStyle = undefined;
+  });
+
+  useEffect(() => {
+    if (!bodyScrollLock) return;
+
+    if (visible) {
+      lockBody();
+    } else {
+      unlockBody();
+    }
+  }, [visible, bodyScrollLock]);
+
+  return createPortal(node, document.body, 'ScreenCover');
 };
 
 export default ScreenCover;

--- a/packages/pocket/src/screen-cover/demo/basic.tsx
+++ b/packages/pocket/src/screen-cover/demo/basic.tsx
@@ -1,24 +1,44 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ScreenCover } from '@orca-fe/pocket';
-import { Button, Spin } from 'antd';
+import { Button, Flex, Progress } from 'antd';
+import { useRafInterval } from 'ahooks';
 
 const Demo = () => {
-  const [open, setOpen] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [percent, setPercent] = useState(0);
+  const [delay, setDelay] = useState<number>();
 
   const handleClick = () => {
-    setOpen(true);
-    setTimeout(() => {
-      setOpen(false);
-    }, 3000);
+    setVisible(true);
+    setDelay(1000);
   };
+
+  useRafInterval(
+    () => {
+      setPercent(percent + Math.floor(Math.random() * 11) + 10);
+    },
+    delay,
+    { immediate: false },
+  );
+
+  useEffect(() => {
+    if (percent >= 100) {
+      setPercent(0);
+      setDelay(undefined);
+      setVisible(false);
+    }
+  }, [percent]);
 
   return (
     <div>
       <Button type="primary" onClick={handleClick}>
         全屏加载
       </Button>
-      <ScreenCover open={open}>
-        <Spin spinning size="large" />
+      <ScreenCover visible={visible} bodyScrollLock>
+        <Flex vertical align="center" justify="center" gap={6}>
+          <div>进度加载中...</div>
+          <Progress type="line" steps={25} percent={percent} />
+        </Flex>
       </ScreenCover>
     </div>
   );

--- a/packages/pocket/src/screen-cover/demo/basic.tsx
+++ b/packages/pocket/src/screen-cover/demo/basic.tsx
@@ -34,7 +34,7 @@ const Demo = () => {
       <Button type="primary" onClick={handleClick}>
         全屏加载
       </Button>
-      <ScreenCover visible={visible} bodyScrollLock>
+      <ScreenCover visible={visible}>
         <Flex vertical align="center" justify="center" gap={6}>
           <div>进度加载中...</div>
           <Progress type="line" steps={25} percent={percent} />

--- a/packages/pocket/src/screen-cover/demo/basic.tsx
+++ b/packages/pocket/src/screen-cover/demo/basic.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { ScreenCover } from '@orca-fe/pocket';
+import { Button, Spin } from 'antd';
+
+const Demo = () => {
+  const [open, setOpen] = useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+    setTimeout(() => {
+      setOpen(false);
+    }, 3000);
+  };
+
+  return (
+    <div>
+      <Button type="primary" onClick={handleClick}>
+        全屏加载
+      </Button>
+      <ScreenCover open={open}>
+        <Spin spinning size="large" />
+      </ScreenCover>
+    </div>
+  );
+};
+
+export default Demo;

--- a/packages/pocket/src/screen-cover/demo/basic.tsx
+++ b/packages/pocket/src/screen-cover/demo/basic.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ScreenCover } from '@orca-fe/pocket';
-import { Button, Flex, Progress } from 'antd';
+import { Button, Flex, Progress, message } from 'antd';
 import { useRafInterval } from 'ahooks';
 
 const Demo = () => {
@@ -26,6 +26,7 @@ const Demo = () => {
       setPercent(0);
       setDelay(undefined);
       setVisible(false);
+      message.success('数据加载完成');
     }
   }, [percent]);
 
@@ -36,7 +37,7 @@ const Demo = () => {
       </Button>
       <ScreenCover visible={visible}>
         <Flex vertical align="center" justify="center" gap={6}>
-          <div>进度加载中...</div>
+          <div style={{ color: '#d3d3d3' }}>进度加载中...</div>
           <Progress type="line" steps={25} percent={percent} />
         </Flex>
       </ScreenCover>

--- a/packages/pocket/src/screen-cover/demo/position.tsx
+++ b/packages/pocket/src/screen-cover/demo/position.tsx
@@ -1,0 +1,27 @@
+import { Button, Spin } from 'antd';
+import { useState } from 'react';
+import ScreenCover from '../ScreenCover';
+
+const Demo = () => {
+  const [visible, setVisible] = useState<boolean>();
+
+  const handleClick = () => {
+    setVisible(true);
+    setTimeout(() => {
+      setVisible(false);
+    }, 3000);
+  };
+
+  return (
+    <div>
+      <Button type="primary" onClick={handleClick}>
+        全屏加载（top 100px）
+      </Button>
+      <ScreenCover visible={visible} position={{ top: 100 }}>
+        <Spin spinning size="large" />
+      </ScreenCover>
+    </div>
+  );
+};
+
+export default Demo;

--- a/packages/pocket/src/screen-cover/index.md
+++ b/packages/pocket/src/screen-cover/index.md
@@ -10,7 +10,39 @@ group:
 
 全屏覆盖组件
 
-## 示例
+## 何时使用
+
+当你不需要使用 `Modal` 来进行操作和提示，但又需要一个可以覆盖全屏的组件时，可以使用 `ScreenCover`。
+
+## 代码演示
 
 <code title="基本用法" src="./demo/basic.tsx"></code>
 <code title="使用 position 调整内容位置" src="./demo/position.tsx"></code>
+
+## API
+
+| 属性           | 说明               | 类型                                                      | 默认值  |
+| -------------- | ------------------ | --------------------------------------------------------- | ------- |
+| visible        | 是否可见           | `boolean`                                                 | `false` |
+| mask           | 是否显示遮罩层     | `boolean`                                                 | `true`  |
+| bodyScrollLock | 是否锁定 body 滚动 | `boolean \| 'x' \| 'y'`                                   | `true`  |
+| position       | 内容位置           | [ScreenCoverContentPosition](#screencovercontentposition) | -       |
+| zIndex         | 层级               | `number`                                                  | 1000    |
+
+### bodyScrollLock
+
+`bodyScrollLock` 用于控制全屏覆盖时是否锁定 body 的滚动条，默认锁定。
+
+- `true`：锁定 body 滚动条
+- `false`：不锁定 body 滚动条
+- `'x'`：锁定 body 水平滚动条
+- `'y'`：锁定 body 垂直滚动条
+
+### ScreenCoverContentPosition
+
+`position` 属性控制内容区的位置，默认为水平垂直居中。
+
+| 属性 | 说明       | 类型               | 默认值 |
+| ---- | ---------- | ------------------ | ------ |
+| top  | 顶部偏移量 | `number \| string` | -      |
+| left | 左侧偏移量 | `number \| string` | -      |

--- a/packages/pocket/src/screen-cover/index.md
+++ b/packages/pocket/src/screen-cover/index.md
@@ -13,3 +13,4 @@ group:
 ## 示例
 
 <code title="基本用法" src="./demo/basic.tsx"></code>
+<code title="使用 position 调整内容位置" src="./demo/position.tsx"></code>

--- a/packages/pocket/src/screen-cover/index.md
+++ b/packages/pocket/src/screen-cover/index.md
@@ -1,0 +1,15 @@
+---
+title: ScreenCover 全屏覆盖组件
+
+group:
+  title: 基础组件
+  path: /base
+---
+
+# ScreenCover
+
+全屏覆盖组件
+
+## 示例
+
+<code title="基本用法" src="./demo/basic.tsx"></code>

--- a/packages/pocket/src/screen-cover/index.ts
+++ b/packages/pocket/src/screen-cover/index.ts
@@ -1,0 +1,5 @@
+import ScreenCover from './ScreenCover';
+
+export default ScreenCover;
+
+export * from './ScreenCover';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,9 @@ importers:
       rc-tooltip:
         specifier: ^6.1.3
         version: 6.1.3(react-dom@18.2.0)(react@17.0.2)
+      rc-util:
+        specifier: ^5.39.1
+        version: 5.39.1(react-dom@18.2.0)(react@17.0.2)
       react:
         specifier: '>=16.8.0'
         version: 17.0.2
@@ -667,7 +670,7 @@ packages:
       '@ant-design/icons-svg': 4.2.1
       '@babel/runtime': 7.23.7
       classnames: 2.3.2
-      rc-util: 5.32.0(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.38.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -699,7 +702,7 @@ packages:
       '@ant-design/icons-svg': 4.2.1
       '@babel/runtime': 7.22.3
       classnames: 2.3.2
-      rc-util: 5.32.0(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.38.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -715,7 +718,7 @@ packages:
       '@ant-design/icons-svg': 4.3.1
       '@babel/runtime': 7.23.7
       classnames: 2.3.2
-      rc-util: 5.35.0(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.38.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -2865,7 +2868,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.7
       classnames: 2.3.2
-      rc-util: 5.38.1(react-dom@18.2.0)(react@17.0.2)
+      rc-util: 5.39.1(react-dom@18.2.0)(react@17.0.2)
       react: 17.0.2
       react-dom: 18.2.0(react@17.0.2)
     dev: false
@@ -2879,7 +2882,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.7
       classnames: 2.3.2
-      rc-util: 5.38.1(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.39.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -2946,7 +2949,7 @@ packages:
       classnames: 2.3.2
       rc-motion: 2.9.0(react-dom@18.2.0)(react@17.0.2)
       rc-resize-observer: 1.4.0(react-dom@18.2.0)(react@17.0.2)
-      rc-util: 5.38.1(react-dom@18.2.0)(react@17.0.2)
+      rc-util: 5.39.1(react-dom@18.2.0)(react@17.0.2)
       react: 17.0.2
       react-dom: 18.2.0(react@17.0.2)
     dev: false
@@ -4834,7 +4837,7 @@ packages:
       rc-tree: 5.7.4(react-dom@18.2.0)(react@18.2.0)
       rc-tree-select: 5.9.0(react-dom@18.2.0)(react@18.2.0)
       rc-upload: 4.3.4(react-dom@18.2.0)(react@18.2.0)
-      rc-util: 5.32.0(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.38.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.0.6
@@ -14428,7 +14431,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.7
       classnames: 2.3.2
-      rc-util: 5.38.1(react-dom@18.2.0)(react@17.0.2)
+      rc-util: 5.39.1(react-dom@18.2.0)(react@17.0.2)
       react: 17.0.2
       react-dom: 18.2.0(react@17.0.2)
     dev: false
@@ -14665,7 +14668,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.7
       classnames: 2.3.2
-      rc-util: 5.38.1(react-dom@18.2.0)(react@17.0.2)
+      rc-util: 5.39.1(react-dom@18.2.0)(react@17.0.2)
       react: 17.0.2
       react-dom: 18.2.0(react@17.0.2)
       resize-observer-polyfill: 1.5.1
@@ -14758,7 +14761,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.7
       classnames: 2.3.2
-      rc-util: 5.38.1(react-dom@18.2.0)(react@17.0.2)
+      rc-util: 5.39.1(react-dom@18.2.0)(react@17.0.2)
       react: 17.0.2
       react-dom: 18.2.0(react@17.0.2)
     dev: false
@@ -15082,32 +15085,20 @@ packages:
       react-is: 16.13.1
     dev: false
 
-  /rc-util@5.32.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-/AJTm1Na+ltHsfhUWodb9Gm1/cYyw0Cx8LrDBO6H0JT35WSMx3/2zXxFwmcVI1M8QnFKecwQNDBeVT1m2iw/vg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.23.7
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 16.13.1
-    dev: false
-
-  /rc-util@5.35.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-MTXlixb3EoSTEchsOc7XWsVyoUQqoCsh2Z1a2IptwNgqleMF6ZgQeY52UzUbNj5CcVBg9YljOWjuOV07jSSm4Q==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.23.7
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 16.13.1
-    dev: false
-
-  /rc-util@5.38.1(react-dom@18.2.0)(react@17.0.2):
+  /rc-util@5.38.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-e4ZMs7q9XqwTuhIK7zBIVFltUtMSjphuPPQXHoHlzRzNdOwUxDejo0Zls5HYaJfRKNURcsS/ceKVULlhjBrxng==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    dependencies:
+      '@babel/runtime': 7.23.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 18.2.0
+    dev: false
+
+  /rc-util@5.39.1(react-dom@18.2.0)(react@17.0.2):
+    resolution: {integrity: sha512-OW/ERynNDgNr4y0oiFmtes3rbEamXw7GHGbkbNd9iRr7kgT03T6fT0b9WpJ3mbxKhyOcAHnGcIoh5u/cjrC2OQ==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -15118,8 +15109,8 @@ packages:
       react-is: 18.2.0
     dev: false
 
-  /rc-util@5.38.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-e4ZMs7q9XqwTuhIK7zBIVFltUtMSjphuPPQXHoHlzRzNdOwUxDejo0Zls5HYaJfRKNURcsS/ceKVULlhjBrxng==}
+  /rc-util@5.39.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-OW/ERynNDgNr4y0oiFmtes3rbEamXw7GHGbkbNd9iRr7kgT03T6fT0b9WpJ3mbxKhyOcAHnGcIoh5u/cjrC2OQ==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'


### PR DESCRIPTION
当业务场景中不需要使用 `Modal` 的功能和样式来进行操作和提示，但又需要一个可以覆盖全屏的组件时，可以使用 `ScreenCover`。